### PR TITLE
fix: check pillow version from __version__

### DIFF
--- a/kitti360scripts/helpers/csHelpers.py
+++ b/kitti360scripts/helpers/csHelpers.py
@@ -16,7 +16,7 @@ import traceback
 # Image processing
 # Check if PIL is actually Pillow as expected
 try:
-    from PIL import PILLOW_VERSION
+    from PIL import __version__ as PILLOW_VERSION
 except:
     print("Please install the module 'Pillow' for image processing, e.g.")
     print("pip install pillow")

--- a/kitti360scripts/viewer/kitti360Viewer.py
+++ b/kitti360scripts/viewer/kitti360Viewer.py
@@ -23,7 +23,7 @@ import numpy as np
 try:
     import matplotlib.colors
     import matplotlib.cm
-    from PIL import PILLOW_VERSION
+    from PIL import __version__ as PILLOW_VERSION
     from PIL import Image
 except:
     pass

--- a/kitti360scripts/viewer/kitti360Viewer3D.py
+++ b/kitti360scripts/viewer/kitti360Viewer3D.py
@@ -31,7 +31,7 @@ import struct
 import argparse
 try:
     import matplotlib.colors
-    from PIL import PILLOW_VERSION
+    from PIL import __version__ as PILLOW_VERSION
     from PIL import Image
 except:
     pass


### PR DESCRIPTION
PILLOW_VERSION has been removed in v7.0.0. See:
https://pillow.readthedocs.io/en/stable/releasenotes/7.0.0.html\#pillow-version-constant